### PR TITLE
Refresh paused Pandora station on resume instead of keep-alive auto-skip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,18 @@ The following configuration values are available:
   players. Setting this to ``0`` will disable caching completely and ensure that the latest lists are always retrieved
   directly from the Pandora server. Defaults to ``86400`` (i.e. 24 hours).
 
+- ``pandora/keep_alive_enabled``: when enabled, the extension keeps a paused
+  station's session token alive by briefly skipping to the next track on a
+  timer. These skips make blocking calls into Mopidy core and can stall the
+  server, so this is **disabled by default**. Defaults to ``false``.
+
+- ``pandora/pause_refresh_interval``: the number of seconds a station may stay
+  paused before a resume recalls the station and re-queues a fresh playlist
+  (Pandora stream URLs expire while paused). When a station is resumed within
+  this interval, playback resumes normally; once the interval has elapsed, the
+  station is reloaded so that the user resumes on a live stream rather than an
+  expired one. Defaults to ``600`` (i.e. 10 minutes).
+
 It is also possible to apply Pandora ratings and perform other actions on the currently playing track using the standard
 pause/play/previous/next buttons.
 

--- a/mopidy_pandora/__init__.py
+++ b/mopidy_pandora/__init__.py
@@ -86,6 +86,9 @@ class Extension(ext.Extension):
         schema["keep_alive_enabled"] = config.Boolean(optional=True)
         schema["keep_alive_interval"] = config.Integer(minimum=300, optional=True)
         schema["keep_alive_double_skip"] = config.Boolean(optional=True)
+        # Seconds a Pandora station may stay paused before a resume triggers a
+        # fresh re-queue of the station instead of resuming a stale stream.
+        schema["pause_refresh_interval"] = config.Integer(minimum=60, optional=True)
         schema["log_cache_misses"] = config.Boolean(optional=True)
         return schema
 

--- a/mopidy_pandora/backend.py
+++ b/mopidy_pandora/backend.py
@@ -52,6 +52,26 @@ class PandoraBackend(
     def end_of_tracklist_reached(self, station_id=None, auto_play=False):
         self.prepare_next_track(station_id, auto_play)
 
+    def reload_station(self, station_id=None, auto_play=True):
+        """Drop the cached playlist for a station and queue a fresh track.
+
+        Triggered by the frontend when a station is resumed after a long pause,
+        so the user gets a live stream URL instead of an expired one.
+        """
+        if not station_id:
+            return
+        logger.info(
+            "Reloading Pandora station '%s' with a fresh playlist after pause.",
+            station_id,
+        )
+        try:
+            self.library.invalidate_station(station_id)
+        except Exception:
+            logger.exception(
+                "Error invalidating station '%s' during reload.", station_id
+            )
+        self.prepare_next_track(station_id, auto_play)
+
     def prepare_next_track(self, station_id, auto_play=False):
         self._trigger_next_track_available(
             self.library.get_next_pandora_track(station_id), auto_play

--- a/mopidy_pandora/ext.conf
+++ b/mopidy_pandora/ext.conf
@@ -13,6 +13,15 @@ sort_order = a-z
 auto_setup = true
 cache_time_to_live = 86400
 
+# Pandora pause handling.
+# The legacy keep-alive auto-skip (skipping to the next track while paused to
+# keep the session token alive) can block/hang the Mopidy server, so it is
+# disabled by default. Instead, when a station has been paused for at least
+# `pause_refresh_interval` seconds and the user resumes, the station is recalled
+# and re-queued with a fresh playlist (see frontend.PandoraFrontend).
+keep_alive_enabled = false
+pause_refresh_interval = 600
+
 event_support_enabled = false
 double_click_interval = 2.50
 on_pause_resume_click = thumbs_up

--- a/mopidy_pandora/frontend.py
+++ b/mopidy_pandora/frontend.py
@@ -96,15 +96,26 @@ class PandoraFrontend(
         self.track_change_completed_event = threading.Event()
         self.track_change_completed_event.set()
         
-        # Keep-alive timer attributes
+        # Legacy keep-alive auto-skip. Disabled by default: skipping to the next
+        # track while paused (to keep the Pandora session token alive) can block
+        # the Mopidy server. The pause/resume refresh below replaces it.
         self.keep_alive_timer = None
-        self.keep_alive_enabled = self.config.get("keep_alive_enabled", True)
+        self.keep_alive_enabled = self.config.get("keep_alive_enabled", False)
         self.keep_alive_interval = self.config.get("keep_alive_interval", 1800)  # 30 minutes default
         self.keep_alive_double_skip = self.config.get("keep_alive_double_skip", False)
-        logger.info(f"PandoraFrontend: Keep-alive initialized - enabled={self.keep_alive_enabled}, interval={self.keep_alive_interval}s, double_skip={self.keep_alive_double_skip}")
+        # Pause/resume refresh: when a station has been paused for at least this
+        # many seconds, a resume recalls the station and re-queues a fresh
+        # playlist instead of resuming a (likely expired) stream.
+        self.pause_refresh_interval = self.config.get("pause_refresh_interval", 600)  # 10 minutes default
+        logger.info(
+            f"PandoraFrontend: keep_alive_enabled={self.keep_alive_enabled}, "
+            f"keep_alive_interval={self.keep_alive_interval}s, "
+            f"pause_refresh_interval={self.pause_refresh_interval}s"
+        )
         # Ad/account/paused state tracking (best-effort, minimal change)
         self.account_ad_supported = None  # None=unknown, True=free/ad-supported, False=premium
         self.paused_at = None
+        self.paused_station_id = None
         self.keepalive_attempts_in_pause = 0
     
     def on_stop(self):
@@ -160,26 +171,50 @@ class PandoraFrontend(
         if not self.track_change_completed_event.is_set():
             self.track_change_completed_event.set()
             self.update_tracklist(tl_track.track)
-        # Start keep-alive timer when paused
+        # Record when (and which station) playback was paused so a later resume
+        # can decide whether to refresh a stale session.
+        try:
+            self.paused_at = int(time.time())
+            self.paused_station_id = PandoraUri.factory(
+                tl_track.track.uri
+            ).station_id
+            self.keepalive_attempts_in_pause = 0
+        except Exception:
+            self.paused_station_id = None
+        # Legacy keep-alive auto-skip (disabled by default).
         if self.keep_alive_enabled:
             self._start_keep_alive_timer()
-        # Mark pause start time for policy decisions
-        try:
-            if self.paused_at is None:
-                import time as _time
-                self.paused_at = int(_time.time())
-                self.keepalive_attempts_in_pause = 0
-        except Exception:
-            pass
 
     @only_execute_for_pandora_uris
     def track_playback_resumed(self, tl_track, time_position):
         self.set_options()
-        # Stop keep-alive timer when resumed
+        # Stop any legacy keep-alive timer.
         self._stop_keep_alive_timer()
-        # Clear pause session state
+
+        # Decide whether the paused session is stale and needs a fresh re-queue.
+        paused_seconds = 0
+        if self.paused_at:
+            try:
+                paused_seconds = max(0, int(time.time()) - int(self.paused_at))
+            except Exception:
+                paused_seconds = 0
+        station_id = self.paused_station_id
+
+        # Clear pause state up front so the re-queue's own pause/resume/play
+        # events don't re-enter this logic.
         self.paused_at = None
+        self.paused_station_id = None
         self.keepalive_attempts_in_pause = 0
+
+        if station_id and paused_seconds >= self.pause_refresh_interval:
+            logger.info(
+                "PandoraFrontend: resumed after %ss paused (>= %ss threshold); "
+                "recalling station %s with a fresh playlist.",
+                paused_seconds,
+                self.pause_refresh_interval,
+                station_id,
+            )
+            self._refresh_station_after_pause(station_id)
 
     def is_end_of_tracklist_reached(self, track=None):
         length = self.core.tracklist.get_length().get()
@@ -276,7 +311,38 @@ class PandoraFrontend(
             station_id=station_id,
             auto_play=auto_play,
         )
-    
+
+    @run_async
+    def _refresh_station_after_pause(self, station_id):
+        """Recall the recently-played station and re-queue a fresh track.
+
+        Runs on a worker thread so the frontend actor is never blocked. Stops
+        playback and clears the tracklist, then asks the backend to drop its
+        cached playlist for the station and queue a fresh, playable track
+        (auto-played). The backend owns the library/cache, so the actual reload
+        happens there via the ``reload_station`` listener event.
+        """
+        try:
+            self.core.playback.stop().get()
+        except Exception:
+            logger.exception(
+                "PandoraFrontend: error stopping playback during station refresh."
+            )
+        try:
+            self.core.tracklist.clear().get()
+        except Exception:
+            logger.exception(
+                "PandoraFrontend: error clearing tracklist during station refresh."
+            )
+        self._trigger_reload_station(station_id, auto_play=True)
+
+    def _trigger_reload_station(self, station_id, auto_play=True):
+        listener.PandoraFrontendListener.send(
+            "reload_station",
+            station_id=station_id,
+            auto_play=auto_play,
+        )
+
     def _start_keep_alive_timer(self):
         """Start the keep-alive timer when playback is paused."""
         self._stop_keep_alive_timer()  # Cancel any existing timer

--- a/mopidy_pandora/listener.py
+++ b/mopidy_pandora/listener.py
@@ -77,6 +77,21 @@ class PandoraFrontendListener(listener.Listener):
         """
         pass
 
+    def reload_station(self, station_id, auto_play=False):
+        """
+        Called when a Pandora station that has been paused for longer than
+        ``pause_refresh_interval`` is resumed. The backend should invalidate any
+        cached playlist for the station and queue a fresh, playable track so the
+        user resumes on a live stream rather than an expired one.
+
+        :param station_id: the ID of the station to reload.
+        :type station_id: string
+        :param auto_play: specifies if the fresh track should be played as soon
+            as it is added to the tracklist.
+        :type auto_play: boolean
+        """
+        pass
+
 
 class PandoraBackendListener(backend.BackendListener):
 


### PR DESCRIPTION
## Summary

Replaces the pause-time "keep-alive" auto-skip with a resume-time station refresh.

When playback is paused, the existing keep-alive mechanism keeps the Pandora
session token alive by briefly skipping to the next track on a timer. Those
skips make blocking calls into Mopidy core (`mixer.set_volume().get()`,
`playback.next().get()`, `playback.pause().get()`); if the audio backend or a
Pandora request stalls, the frontend thread blocks and the whole Mopidy server
can become unresponsive.

This PR disables that auto-skip by default and instead refreshes the station
**when the user resumes**:

- On pause, record when (and which station) playback was paused.
- On resume, if the station was paused for at least `pause_refresh_interval`
  (default 600 s), stop, clear the tracklist, invalidate the station's cached
  playlist, and queue a fresh, playable track (auto-played). Shorter pauses
  resume normally.

Pandora stream URLs expire while paused, so after a long pause the user resumes
on a live stream rather than a dead one. Because Pandora is radio, this resumes
on a fresh track from the *same station* (not the exact paused track).

## Why this is self-contained

No Mopidy core changes are required. The refresh runs on a worker thread
(`@run_async`) so the actor is never blocked, and the reload is performed via
the existing listener bus: the frontend emits a new `reload_station` event, the
backend invalidates the station cache and queues a fresh track through the
existing `next_track_available` flow.

## Configuration changes

- `pandora/keep_alive_enabled`: default changes from `true` to **`false`**.
  Existing installs that did not set this explicitly will no longer perform the
  pause-time auto-skip. Set it back to `true` to restore the old behaviour.
- `pandora/pause_refresh_interval` (new, optional, integer, min 60): seconds a
  station may stay paused before a resume reloads it. Defaults to `600`.

Example `mopidy.conf`:

```ini
[pandora]
keep_alive_enabled = false
pause_refresh_interval = 600
```

Both options are documented in `README.rst` and the bundled `ext.conf`.

## Behaviour notes / edge cases

- After the interval, resume plays a fresh track from the same station (radio
  semantics), not the exact paused track at its previous position.
- If the fresh fetch fails (e.g. an expired session token after a very long
  pause), `get_next_pandora_track` returns `None` and playback stops cleanly —
  no hang; the user re-selects the station. A follow-up could force an API
  re-login in `reload_station`.
- Pause state is cleared before the async refresh runs, so the re-queue's own
  play events do not re-enter the refresh logic.
- No interaction with `event_support_enabled` double-click events, which fire
  within `double_click_interval` (~2.5 s), well under the refresh interval.
- The legacy keep-alive code remains in place and inert unless re-enabled.

## Testing

- Pause a station < interval, resume → normal resume.
- Pause a station >= interval, resume → station reloads and a fresh track plays;
  Mopidy stays responsive throughout the pause (no stalled keep-alive skip).
